### PR TITLE
Adding Sliding Gate and Garage Door states and feedback to domoticz

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Supported devices:
 - Awning
 - Pergolas
 - Garage door
+- Sliding Gate
 - Windows
 - Venetian blinds (positions + slats control)
 - Luminance sensor

--- a/plugin.py
+++ b/plugin.py
@@ -727,6 +727,13 @@ class BasePlugin:
                         lumlevel = state["value"]
                         lumstatus_l = True
 
+                    elif state["name"] in ("core:OpenClosedPedestrianState", "core:OpenClosedPartialState"):
+                        if state["value"] == "closed":
+                            level = 0
+                        elif state["value"] == "open":
+                            level = 100
+                        status_num = 1
+
                     Domoticz.Debug("checking for update on state[name]: '" + state["name"] + "' with status_num = '" + str(status_num) + "' for device: '" + dev + "'")
 
                     if status_num > 0 and level is not None:

--- a/utils.py
+++ b/utils.py
@@ -6,7 +6,9 @@ stateSet = {
     "core:ClosureState",
     "core:OpenClosedState",
     "core:LuminanceState",
-    "core:DeploymentState"
+    "core:DeploymentState",
+    "core:OpenClosedPartialState",
+    "core:OpenClosedPedestrianState"
 }
 
 # Supported uiClasses for io:// and rts:// devices


### PR DESCRIPTION
Hello,

I add additional states from Somfy API to supports for IO Garage Doors / Gates with Partial / Pedestrian States.
It adds : 
OpenClosedPartialState
OpenClosedPedestrianState

And feedback states to domoticz in plugin.py.

Regards,
Ludovic