### PR TITLE
Bound retry backoff, scope TLS-warning suppression, clean up dead callbacks

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -7,10 +7,10 @@
 #
 ###################################################################################
 """
-<plugin key="tahomaIO" name="Somfy Tahoma or Connexoon plugin" author="MadPatrick" version="5.3.3" externallink="https://github.com/MadPatrick/somfy">
+<plugin key="tahomaIO" name="Somfy Tahoma or Connexoon plugin" author="MadPatrick" version="5.3.4" externallink="https://github.com/MadPatrick/somfy">
     <description>
         <h2>Somfy TaHoma / Connexoon</h2>
-        <p><strong>Version:</strong> 5.3.3</p>
+        <p><strong>Version:</strong> 5.3.4</p>
         <p>Connects Domoticz to a Somfy TaHoma or Connexoon gateway through the local API or legacy web API.</p>
         <h3>Features</h3>
         <ul>
@@ -409,24 +409,12 @@ class BasePlugin:
         self.heartbeat = False
 
     def onConnect(self, Connection, Status, Description):
-        Domoticz.Debug("onConnect: Connection: '"+str(Connection)+"', Status: '"+str(Status)+"', Description: '"+str(Description)+"' self.tahoma.logged_in: '"+str(self.tahoma.logged_in)+"'")
-        if (Status == 0 and not self.local and not self.tahoma.logged_in):
-            self._ensure_web_login()
-        elif ((self.local or self.tahoma.logged_in) and (not self.command)):
-            event_list = self.tahoma.get_events()
-            self.update_devices_status(event_list)
-        elif (self.command):
-            self.tahoma.send_command(self.command_data)
-            try:
-                event_list = self.tahoma.get_events()
-                self.update_devices_status(event_list)
-            except Exception as e:
-                Domoticz.Debug("Could not fetch events after command: " + str(e))
-            self.command = False
-            self.heartbeat = False
-            self.actions_serialized = []
-        else:
-            logging.info("Failed to connect to tahoma api")
+        # Not used by this plugin: no Domoticz.Connection(...) object is ever
+        # created, so Domoticz never invokes this callback. All I/O (login,
+        # event fetch, command dispatch) happens synchronously via
+        # onCommand/onHeartbeat instead. Kept as a no-op because Domoticz
+        # requires the callback to exist.
+        Domoticz.Debug("onConnect called (not used by this plugin; I/O is synchronous via onCommand/onHeartbeat)")
 
     def refresh_daily_data(self):
         """
@@ -508,7 +496,10 @@ class BasePlugin:
         return f"Day starts {day_str} | Night starts {night_str}"
 
     def onMessage(self, Connection, Data):
-        Domoticz.Debug("onMessage called (not implemented). Data: " + str(Data))
+        # Not used by this plugin: no Domoticz.Connection(...) object is ever
+        # created, so Domoticz never invokes this callback. Kept as a no-op
+        # because Domoticz requires the callback to exist.
+        Domoticz.Debug("onMessage called (not used by this plugin; I/O is synchronous via onCommand/onHeartbeat)")
 
     def onCommand(self, DeviceId, Unit, Command, Level, Hue):
         Domoticz.Debug(f"onCommand: DeviceId: {DeviceId}, Unit: {Unit}, Command: {Command}, Level: {Level}, Hue: {Hue}")
@@ -622,7 +613,10 @@ class BasePlugin:
         return True
 
     def onDisconnect(self, Connection):
-        return
+        # Not used by this plugin: no Domoticz.Connection(...) object is ever
+        # created, so Domoticz never invokes this callback. Kept as a no-op
+        # because Domoticz requires the callback to exist.
+        Domoticz.Debug("onDisconnect called (not used by this plugin; I/O is synchronous via onCommand/onHeartbeat)")
 
     def onHeartbeat(self):
         self.runCounter -= 1

--- a/tahoma.py
+++ b/tahoma.py
@@ -176,7 +176,7 @@ class Tahoma:
                     break
             except requests.exceptions.RequestException as exp:
                 logging.error("get_devices RequestException: " + str(exp))
-            time.sleep(i ** 3)
+            time.sleep(min(2 * i, 5))
         else:
             raise exceptions.TooManyRetries
 
@@ -256,7 +256,7 @@ class Tahoma:
 
             except requests.exceptions.RequestException as exp:
                 logging.error("get_events RequestException: " + str(exp))
-            time.sleep(i ** 3)
+            time.sleep(min(2 * i, 5))
         else:
             raise exceptions.TooManyRetries
 

--- a/tahoma_local.py
+++ b/tahoma_local.py
@@ -9,8 +9,21 @@ import utils
 import listener
 import DomoticzEx as Domoticz
 
+import warnings
 import urllib3
-urllib3.disable_warnings()
+from contextlib import contextmanager
+
+
+@contextmanager
+def _suppress_insecure_warning():
+    """Locally suppress urllib3's InsecureRequestWarning for requests to the
+    local Somfy/TaHoma hub, which uses a self-signed certificate by design
+    (verify=False). Scoped to this context only, instead of disabling the
+    warning process-wide for the whole interpreter."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+        yield
+
 
 class TahomaWebApi:
     base_url_web = "https://ha101-1.overkiz.com"
@@ -170,7 +183,8 @@ class SomfyBox(TahomaWebApi):
     def get_version(self):
         if self.token is None or self.token == "0":
             raise exceptions.TahomaException("No token has been provided")
-        response = requests.get(self.base_url_local + "/apiVersion", headers=self.headers_with_token, verify=False, timeout=10)
+        with _suppress_insecure_warning():
+            response = requests.get(self.base_url_local + "/apiVersion", headers=self.headers_with_token, verify=False, timeout=10)
         if response.status_code == 200:
             data = utils.response_json(response, "get API version")
             logging.debug("succeeded to get API version: " + str(data))
@@ -183,7 +197,8 @@ class SomfyBox(TahomaWebApi):
     def get_gateways(self):
         if self.token is None or self.token == "0":
             raise exceptions.TahomaException("No token has been provided")
-        response = requests.get(self.base_url_local + "/setup/gateways", headers=self.headers_with_token, verify=False, timeout=10)
+        with _suppress_insecure_warning():
+            response = requests.get(self.base_url_local + "/setup/gateways", headers=self.headers_with_token, verify=False, timeout=10)
         logging.debug(response)
         if response.status_code == 200:
             data = utils.response_json(response, "get gateways")
@@ -200,12 +215,13 @@ class SomfyBox(TahomaWebApi):
             raise exceptions.TahomaException("No token has been provided")
 
         try:
-            response = requests.get(
-                self.base_url_local + "/setup/devices",
-                headers=self.headers_with_token,
-                verify=False,
-                timeout=10
-            )
+            with _suppress_insecure_warning():
+                response = requests.get(
+                    self.base_url_local + "/setup/devices",
+                    headers=self.headers_with_token,
+                    verify=False,
+                    timeout=10
+                )
         except requests.exceptions.RequestException as exp:
             raise exceptions.TahomaException(
                 f"Failed to get devices: {exp}"
@@ -240,7 +256,8 @@ class SomfyBox(TahomaWebApi):
             raise exceptions.TahomaException("Invalid url, needs to start with io://")
         url = self.base_url_local + "/setup/devices/" + urllib.parse.quote(device, safe="") + "/states"
         logging.debug("url for device state: " + str(url))
-        response = requests.get(url, headers=self.headers_with_token, verify=False, timeout=10)
+        with _suppress_insecure_warning():
+            response = requests.get(url, headers=self.headers_with_token, verify=False, timeout=10)
         logging.debug(response)
         if response.status_code == 200:
             data = utils.response_json(response, "get device state")
@@ -260,7 +277,8 @@ class SomfyBox(TahomaWebApi):
             raise exceptions.NoListenerFailure()
         for i in range(1, 4):
             try:
-                response = requests.post(self.base_url_local + "/events/" + self.listener.listenerId + "/fetch", headers=self.headers_with_token, verify=False, timeout=10)
+                with _suppress_insecure_warning():
+                    response = requests.post(self.base_url_local + "/events/" + self.listener.listenerId + "/fetch", headers=self.headers_with_token, verify=False, timeout=10)
                 logging.debug("get events response: status '" + str(response.status_code) + "' response body: '" + str(response) + "'")
                 if response.status_code != 200:
                     logging.error("error during get events, status: " + str(response.status_code) + ", " + str(response.text))
@@ -288,7 +306,7 @@ class SomfyBox(TahomaWebApi):
                     logging.info("Return status " + str(response.status_code))
             except requests.exceptions.RequestException as exp:
                 logging.error("get_events RequestException: " + str(exp))
-            time.sleep(i ** 3)
+            time.sleep(min(2 * i, 5))
         else:
             raise exceptions.TooManyRetries
         logging.debug("finished get events")
@@ -297,7 +315,8 @@ class SomfyBox(TahomaWebApi):
         logging.debug("start register")
         if self.token is None or self.token == "0":
             raise exceptions.TahomaException("No token has been provided")
-        response = self.listener.register_listener(self.base_url_local + "/events/register", headers=self.headers_with_token, verify=False, timeout=10)
+        with _suppress_insecure_warning():
+            response = self.listener.register_listener(self.base_url_local + "/events/register", headers=self.headers_with_token, verify=False, timeout=10)
         return response
 
     #execution endpoints
@@ -307,7 +326,8 @@ class SomfyBox(TahomaWebApi):
         logging.info("Sending command to local api")
         logging.debug("onCommand: data '"+str(json_data)+"'")
         try:
-            response = requests.post(self.base_url_local + "/exec/apply", headers=self.headers_with_token, json=json_data, verify=False, timeout=self.timeout)
+            with _suppress_insecure_warning():
+                response = requests.post(self.base_url_local + "/exec/apply", headers=self.headers_with_token, json=json_data, verify=False, timeout=self.timeout)
         except requests.exceptions.RequestException as exp:
             logging.error("Send command returns RequestException: " + str(exp))
             return ""


### PR DESCRIPTION
## Summary
- `tahoma.py` / `tahoma_local.py`: replaced the cubic retry backoff (`time.sleep(i ** 3)` — up to 36s of sleeping alone across 3 retries, ~66s worst case including request timeouts) with a bounded linear backoff (`min(2 * i, 5)`s), cutting worst-case blocking of Domoticz's single callback thread substantially without changing retry count or exception semantics.
- `tahoma_local.py`: stopped calling `urllib3.disable_warnings()` at module import time, which silently suppressed `InsecureRequestWarning` for the whole Python process. `verify=False` itself is kept (the local hub uses a self-signed certificate by design, and there's no CA to pin), but the warning is now suppressed only around each individual insecure request via a small local context manager, instead of process-wide.
- `plugin.py`: simplified `onConnect`/`onMessage`/`onDisconnect` to honest no-op stubs. These callbacks contained real-looking (but unreachable) login/event-fetch/command dispatch logic, despite no `Domoticz.Connection` object ever being instantiated anywhere in the plugin — misleading dead code for future maintainers, since all I/O in this plugin is actually synchronous via `onCommand`/`onHeartbeat`.
- Version bumped to `5.3.4`.

## Test plan
- [x] `python3 -m py_compile plugin.py tahoma.py tahoma_local.py listener.py utils.py exceptions.py` passes
- [x] Confirmed via grep that no `Domoticz.Connection(...)` is instantiated anywhere in `plugin.py`, validating that the removed onConnect/onMessage/onDisconnect logic was genuinely unreachable
- [x] Confirmed no remaining `i ** 3` backoff or module-level `disable_warnings()` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqaJNJq26bUDsztvSGtnfr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqaJNJq26bUDsztvSGtnfr)_